### PR TITLE
Bug fixes & new code

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -48,6 +48,10 @@ module.exports = function(config) {
 
         autoWatch: false,
 
+        browserDisconnectTimeout: 30000,
+        browserNoActivityTimeout: 30000,
+        browserDisconnectTolerance: 10,
+
         ngHtml2JsPreprocessor: {
             stripPrefix: conf.paths.src + '/',
             moduleName: 'portal'

--- a/src/app/review/components/acf_patient_list/acf_patient_list.directive.js
+++ b/src/app/review/components/acf_patient_list/acf_patient_list.directive.js
@@ -93,11 +93,13 @@
                 buildTitle();
             }
 
-            function dischargePatient (patient) {
-                commonService.dischargePatient(patient.id).then(function () {
-                    vm.getPatientsAtAcf();
-                });
-                vm.deactivatePatient();
+            function dischargePatient (patientIndex) {
+                if (patientIndex >= 0 && patientIndex < vm.patients.length) {
+                    commonService.dischargePatient(vm.patients[patientIndex].id).then(function () {
+                        vm.getPatientsAtAcf();
+                    });
+                    vm.deactivatePatient();
+                }
             }
 
             function editPatient (patient) {

--- a/src/app/review/components/acf_patient_list/acf_patient_list.directive.spec.js
+++ b/src/app/review/components/acf_patient_list/acf_patient_list.directive.spec.js
@@ -169,24 +169,32 @@
         it('should have a way to discharge patients', function () {
             // given a patient in the queue
             expect(vm.patients.length).toBe(2);
+            var result = angular.copy(mock.patients);
+            result.splice(0,1);
 
-            commonService.getPatientsAtAcf.and.returnValue($q.when([]));
+            commonService.getPatientsAtAcf.and.returnValue($q.when(result));
             // when first result is cleared
-            vm.dischargePatient(vm.patients[0]);
+            vm.dischargePatient(0);
             el.isolateScope().$digest();
 
             // then expect to have one less patient in the queue
-            expect(vm.patients.length).toBe(0);
+            expect(vm.patients.length).toBe(1);
         });
 
         it('should call commonService.dischargePatient on discharge', function () {
-            vm.dischargePatient(vm.patients[0]);
+            vm.dischargePatient(0);
             expect(commonService.dischargePatient).toHaveBeenCalledWith(2);
         });
 
         it('should not try to clear an out of bounds query', function () {
             var patientQueueLength = vm.patients.length;
             vm.dischargePatient(patientQueueLength + 1);
+            expect(vm.patients.length).toBe(patientQueueLength);
+        });
+
+        it('should not try to clear an out of bounds query', function () {
+            var patientQueueLength = vm.patients.length;
+            vm.dischargePatient(-1);
             expect(vm.patients.length).toBe(patientQueueLength);
         });
 
@@ -297,7 +305,7 @@
         it('should change the title when the number of patients changes', function () {
             commonService.getPatientsAtAcf.and.returnValue($q.when([mock.patients[1]]));
             // when first result is cleared
-            vm.dischargePatient(vm.patients[0]);
+            vm.dischargePatient(0);
             el.isolateScope().$digest();
 
             // then expect to have one less patient in the queue
@@ -306,7 +314,7 @@
 
         it('should deactivate a patient when a patient is discharged', function () {
             spyOn(vm,'deactivatePatient');
-            vm.dischargePatient(vm.patients[0]);
+            vm.dischargePatient(0);
             el.isolateScope().$digest();
             expect(vm.deactivatePatient).toHaveBeenCalled();
         });

--- a/src/app/review/components/document_review/document_review.html
+++ b/src/app/review/components/document_review/document_review.html
@@ -7,7 +7,7 @@
       <h2 class="panel-title">Document Review<span ng-if="vm.activeDocument">: {{ vm.activeDocument.className }}</span></h2>
       <div class="clearfix"></div>
     </div>
-    <div class="panel-body" ng-if="!vm.hidePanel">
+    <div class="panel-body">
       <div ng-if="vm.activeDocument">
         Showing&nbsp;
         <select ng-model="vm.displayType">

--- a/src/app/search/components/patient_review/patient_review.directive.js
+++ b/src/app/search/components/patient_review/patient_review.directive.js
@@ -39,6 +39,7 @@
             vm.displayNames = displayNames;
             vm.getQueries = getQueries;
             vm.getRecordCount = getRecordCount;
+            vm.reQuery = reQuery;
             vm.stagePatient = stagePatient;
 
             vm.TIMEOUT_MILLIS = QueryQueryTimeout * 1000;
@@ -100,6 +101,13 @@
                     recordCount += query.locationStatuses[i].results.length;
                 }
                 return recordCount;
+            }
+
+            function reQuery (query) {
+                commonService.searchForPatient(query.terms).then(function () {
+                    vm.getQueries();
+                });
+                vm.clearQuery(query);
             }
 
             function stagePatient (query) {

--- a/src/app/search/components/patient_review/patient_review.directive.js
+++ b/src/app/search/components/patient_review/patient_review.directive.js
@@ -58,7 +58,14 @@
             }
 
             function clearQuery (query) {
-                commonService.clearQuery(query.id).then(function () {
+                var id = query.id;
+                for (var i = 0; i < vm.patientQueries.length; i++) {
+                    if (query.id === vm.patientQueries[i].id) {
+                        vm.patientQueries.splice(i,1);
+                        break;
+                    }
+                }
+                commonService.clearQuery(id).then(function () {
                     vm.getQueries();
                 });
             }
@@ -82,17 +89,9 @@
             }
 
             function getQueries () {
-                commonService.getQueries().then(function (response) {
-                    var hasActive = false;
-                    vm.patientQueries = response;
-                    for (var i = 0; i < vm.patientQueries.length; i++) {
-                        vm.patientQueries[i].recordCount = vm.getRecordCount(vm.patientQueries[i]);
-                        hasActive = hasActive || (vm.patientQueries[i].status === 'Active');
-                    }
-                    if (hasActive) {
-                        $timeout(vm.getQueries, vm.TIMEOUT_MILLIS);
-                    }
-                });
+                if (!vm.activeQuery) {
+                    getQueryHelper();
+                }
             }
 
             function getRecordCount (query) {
@@ -131,6 +130,23 @@
                         vm.getQueries();
                     }
                     $log.debug('dismissed', result);
+                });
+            }
+
+            ////////////////////////////////////////////////////////////////////
+
+            function getQueryHelper () {
+                commonService.getQueries().then(function (response) {
+                    var stillActive = false;
+                    vm.patientQueries = response;
+                    for (var i = 0; i < vm.patientQueries.length; i++) {
+                        vm.patientQueries[i].recordCount = vm.getRecordCount(vm.patientQueries[i]);
+                        stillActive = stillActive || (vm.patientQueries[i].status === 'Active');
+                    }
+                    vm.activeQuery = stillActive;
+                    if (stillActive) {
+                        vm.timeout = $timeout(getQueryHelper, vm.TIMEOUT_MILLIS);
+                    }
                 });
             }
         }

--- a/src/app/search/components/patient_review/patient_review.directive.spec.js
+++ b/src/app/search/components/patient_review/patient_review.directive.spec.js
@@ -38,6 +38,7 @@
                     $delegate.cancelQueryLocation = jasmine.createSpy('cancelQueryLocation');
                     $delegate.clearQuery = jasmine.createSpy('clearQuery');
                     $delegate.getQueries = jasmine.createSpy('getQueries');
+                    $delegate.searchForPatient = jasmine.createSpy('commonService.searchForPatient');
                     $delegate.stagePatient = jasmine.createSpy('stagePatient');
                     return $delegate;
                 });
@@ -57,6 +58,7 @@
                 commonService.cancelQueryLocation.and.returnValue($q.when({}));
                 commonService.clearQuery.and.returnValue($q.when({}));
                 commonService.getQueries.and.returnValue($q.when(mock.queries));
+                commonService.searchForPatient.and.returnValue($q.when({}));
                 commonService.stagePatient.and.returnValue($q.when({}));
 
                 el = angular.element('<ai-patient-review></ai-patient-review>');
@@ -239,6 +241,30 @@
                 vm.stagePatient(vm.patientQueries[0]);
                 vm.stagePatientInstance.dismiss('query cleared');
                 expect(vm.getQueries).toHaveBeenCalled();
+            });
+        });
+
+        describe('requerying', function () {
+            it('should have a function ro requery', function () {
+                expect(vm.reQuery).toBeDefined();
+            });
+
+            it('should call commonService.searchForPatient when requeried', function () {
+                vm.reQuery(mock.queries[0]);
+                expect(commonService.searchForPatient).toHaveBeenCalledWith(mock.queries[0].terms);
+            });
+
+            it('should refresh local queries when requeried', function () {
+                spyOn(vm,'getQueries');
+                vm.reQuery(mock.queries[0]);
+                el.isolateScope().$digest();
+                expect(vm.getQueries).toHaveBeenCalled();
+            });
+
+            it('should call clearQuery to clear the requeried query', function () {
+                spyOn(vm,'clearQuery');
+                vm.reQuery(mock.queries[0]);
+                expect(vm.clearQuery).toHaveBeenCalledWith(mock.queries[0]);
             });
         });
     });

--- a/src/app/search/components/patient_review/patient_review.html
+++ b/src/app/search/components/patient_review/patient_review.html
@@ -49,6 +49,7 @@
                           confirm-cancel="No"
                           confirm-settings="{animation: false, keyboard: false, backdrop: 'static'}"
                           ng-click="vm.clearQuery(query)"><i class="fa fa-trash"></i><span class="sr-only">Clear query for {{ commonService.displayName(query.terms.name) }}</span></button>
+                  <button ng-if="query.status === 'Complete'" class="btn btn-primary btn-sm" ng-click="vm.reQuery(query)"><i class="fa fa-refresh"></i><span class="sr-only">Redo query for {{ commonService.displayName(query.terms.name) }}</span></button>
                 </td>
               </tr>
             </tbody>

--- a/src/app/search/components/patient_review/patient_review.html
+++ b/src/app/search/components/patient_review/patient_review.html
@@ -4,7 +4,7 @@
       <h2 class="panel-title">Queries ({{ vm.patientQueries.length}})</h2>
       <div class="clearfix"></div>
     </div>
-    <div class="panel-body slide" ng-if="!vm.hidePanel">
+    <div class="panel-body">
       <div class="row">
         <div class="col-sm-12">
           <h3>Queried Patient Information</h3>


### PR DESCRIPTION
PULSE-349: Queries stay visible no matter how many there are
PULSE-348: Re-allow discharge of patient
PULSE-341: Re-query entire query
PULSE-350: Only allow one /queries call at a time