### PR TITLE
PULSE-343: make cancel and requery operations use top-level id

### DIFF
--- a/src/app/common/common.service.js
+++ b/src/app/common/common.service.js
@@ -51,8 +51,8 @@
             return enhancedGet('/patients/' + patientId + '/documents/' + documentId);
         }
 
-        function cancelQueryLocation (queryId, locationId) {
-            return enhancedPost('/queries/' + queryId + '/' + locationId + '/cancel', {});
+        function cancelQueryLocation (queryId, locationMapId) {
+            return enhancedPost('/queries/' + queryId + '/locationMap/' + locationMapId + '/cancel', {});
         }
 
         function clearQuery (queryId) {
@@ -279,8 +279,8 @@
                 });
         }
 
-        function requeryLocation (queryId, locationId) {
-            return enhancedPost('/requery/' + queryId + '/location/' + locationId, {});
+        function requeryLocation (queryId, locationMapId) {
+            return enhancedPost('/requery/query/' + queryId + '/locationMap/' + locationMapId, {});
         }
 
         function saveToken (token) {

--- a/src/app/common/common.service.spec.js
+++ b/src/app/common/common.service.spec.js
@@ -64,7 +64,7 @@
 
             spyOn($window.location, 'replace');
             requestHandler.cacheDocument = $httpBackend.whenGET(API + '/patients/3/documents/2').respond(200, true);
-            requestHandler.cancelQueryLocation = $httpBackend.whenPOST(API + '/queries/1/2/cancel', {}).respond(200, true);
+            requestHandler.cancelQueryLocation = $httpBackend.whenPOST(API + '/queries/1/locationMap/2/cancel', {}).respond(200, true);
             requestHandler.clearQuery = $httpBackend.whenPOST(API + '/queries/1/delete', {}).respond(200, true);
             requestHandler.createAcf = $httpBackend.whenPOST(API + '/acfs/create', mock.newAcf).respond(200, mock.newAcf);
             requestHandler.dischargePatient = $httpBackend.whenPOST(API + '/patients/1/delete', {}).respond(200, true);
@@ -79,7 +79,7 @@
             requestHandler.getRestQueryPatientDocuments = $httpBackend.whenGET(API + '/patients/3/documents').respond(200, {results: mock.patientDocuments});
             requestHandler.getSamlUserToken = $httpBackend.whenGET(AuthAPI + '/jwt').respond(200, {token: mock.token});
             requestHandler.refreshToken = $httpBackend.whenGET(AuthAPI + '/jwt/keepalive').respond(200, {token: mock.token});
-            requestHandler.requeryLocation = $httpBackend.whenPOST(API + '/requery/3/location/4', {}).respond(200, {results: mock.patientQueryResponse});
+            requestHandler.requeryLocation = $httpBackend.whenPOST(API + '/requery/query/3/locationMap/4', {}).respond(200, {results: mock.patientQueryResponse});
             requestHandler.setAcf = $httpBackend.whenPOST(AuthAPI + '/jwt/setAcf', {}).respond(200, {token: mock.token});
             requestHandler.stagePatient = $httpBackend.whenPOST(API + '/queries/1/stage', mock.stagePatient).respond(200, {});
         }));
@@ -311,7 +311,7 @@
                 $httpBackend.flush();
             });
 
-            it('should call /queries/locationid/queryid/cancel', function () {
+            it('should call /queries/queryid/locationMap/locationmapid/cancel', function () {
                 commonService.cancelQueryLocation(1,2);
                 $httpBackend.flush();
                 requestHandler.cancelQueryLocation.respond(401, {error: 'test'});
@@ -478,7 +478,7 @@
                 $httpBackend.flush();
             });
 
-            it('should call /requery/{queryId}/location/{locationId}', function () {
+            it('should call /requery/query/{queryId}/locationMap/{locationMapId}', function () {
                 commonService.requeryLocation(3,4);
                 $httpBackend.flush();
                 requestHandler.requeryLocation.respond(401, {error: 'a rejection'});

--- a/src/app/search/components/patient_review/patient_review.directive.js
+++ b/src/app/search/components/patient_review/patient_review.directive.js
@@ -55,7 +55,7 @@
 
             function cancelQueryLocation (locationStatus) {
                 locationStatus.isClearing = true;
-                commonService.cancelQueryLocation(locationStatus.queryId, locationStatus.location.id);
+                commonService.cancelQueryLocation(locationStatus.queryId, locationStatus.id);
             }
 
             function clearQuery (query) {
@@ -112,7 +112,7 @@
 
             function requeryLocation (location) {
                 location.isRequerying = true;
-                commonService.requeryLocation(location.queryId, location.location.id).then(function () {
+                commonService.requeryLocation(location.queryId, location.id).then(function () {
                     vm.getQueries();
                 });
             }

--- a/src/app/search/components/patient_review/patient_review.directive.spec.js
+++ b/src/app/search/components/patient_review/patient_review.directive.spec.js
@@ -195,7 +195,7 @@
 
             it('should call commonService.clearLocationQuery', function () {
                 vm.cancelQueryLocation(vm.patientQueries[0].locationStatuses[0]);
-                expect(commonService.cancelQueryLocation).toHaveBeenCalledWith(vm.patientQueries[0].id, vm.patientQueries[0].locationStatuses[0].location.id);
+                expect(commonService.cancelQueryLocation).toHaveBeenCalledWith(vm.patientQueries[0].id, vm.patientQueries[0].locationStatuses[0].id);
             });
 
             it('should set the location status to "pending" when clearing', function () {
@@ -282,7 +282,7 @@
 
             it('should call commonService.requeryLocation when requeried', function () {
                 vm.requeryLocation(Mock.queries[0].locationStatuses[0]);
-                expect(commonService.requeryLocation).toHaveBeenCalledWith(4,1);
+                expect(commonService.requeryLocation).toHaveBeenCalledWith(4,13);
             });
 
             it('should refresh local queries when requeried', function () {


### PR DESCRIPTION
to coordinate with api change