### PR TITLE
PULSE-371: Display friendly name & identifier

### DIFF
--- a/src/app/components/acf/acf.directive.js
+++ b/src/app/components/acf/acf.directive.js
@@ -28,11 +28,12 @@
             vm.editAcf = editAcf;
             vm.findAcf = findAcf;
             vm.getAcfs = getAcfs;
+            vm.getName = getName;
             vm.getUserAcf = getUserAcf;
             vm.hasAcf = hasAcf;
-            vm.splitAcfNames = splitAcfNames;
+            vm.splitAcfIdentifiers = splitAcfIdentifiers;
             vm.submitForm = submitForm;
-            vm.validName = validName;
+            vm.validIdentifier = validIdentifer;
 
             activate();
 
@@ -47,7 +48,7 @@
             }
 
             function acfSubmit () {
-                if (vm.mode === 'enter' && vm.acf && vm.acf.name) {
+                if (vm.mode === 'enter' && vm.acf && vm.acf.identifier) {
                     var newlines = [];
                     for (var i = 0; i < vm.acf.address.lines.length; i++) {
                         if (vm.acf.address.lines[i] !== '') {
@@ -90,9 +91,9 @@
 
             function findAcf () {
                 if (!vm.acfWritesAllowed) {
-                    var name = vm.selectAcfPrefix + '-' + vm.selectAcfSuffix;
+                    var identifier = vm.selectAcfPrefix + '-' + vm.selectAcfSuffix;
                     for (var i = 0; i < vm.acfs.length; i++) {
-                        if (vm.acfs[i].name === name) {
+                        if (vm.acfs[i].identifier === identifier) {
                             vm.selectAcf = vm.acfs[i];
                             break;
                         }
@@ -104,7 +105,7 @@
                 vm.acfs = [];
                 commonService.getAcfs().then(function (response) {
                     vm.acfs = vm.acfs.concat(response);
-                    vm.splitAcfNames();
+                    vm.splitAcfIdentifiers();
                     if (vm.acfs.length === 0) {
                         if (vm.mode === 'select') {
                             vm.mode = 'enter';
@@ -116,6 +117,15 @@
                         vm.mode = 'enter';
                     }
                 });
+            }
+
+            function getName (identifier) {
+                for (var i = 0; i < vm.acfs.length; i++) {
+                    if (vm.acfs[i].identifier === identifier) {
+                        return vm.acfs[i].name;
+                    }
+                }
+                return '';
             }
 
             function getUserAcf () {
@@ -139,13 +149,13 @@
                 return commonService.hasAcf();
             }
 
-            function splitAcfNames () {
+            function splitAcfIdentifiers () {
                 if (!vm.acfWritesAllowed) {
                     vm.acfPrefixes = [];
                     vm.acfSuffixes = [];
                     var parts;
                     for (var i = 0; i < vm.acfs.length; i++) {
-                        parts = vm.acfs[i].name.split('-');
+                        parts = vm.acfs[i].identifier.split('-');
                         if (vm.acfPrefixes.indexOf(parts[0]) < 0)
                             vm.acfPrefixes.push(parts[0]);
                         if (vm.acfSuffixes.indexOf(parts[1]) < 0)
@@ -164,13 +174,12 @@
                 }
             }
 
-            function validName () {
+            function validIdentifer () {
+                var ret = true;
                 for (var i = 0; i < vm.acfs.length; i++) {
-                    if (vm.acfs[i].name === vm.acf.name) {
-                        return false;
-                    }
+                    ret = ret && (vm.acfs[i].identifier !== vm.acf.identifier);
                 }
-                return true;
+                return ret;
             }
         }
     }

--- a/src/app/components/acf/acf.html
+++ b/src/app/components/acf/acf.html
@@ -15,7 +15,7 @@
             <label for="selectAcf" class="control-label sr-only">ACF Selection</label>
             <div class="col-sm-12">
               <select class="input-sm form-control" ng-model="vm.selectAcf" id="selectAcf" name="selectAcf" ng-disabled="!vm.acfs || vm.acfs.length === 0" ng-required="vm.mode === 'select'"
-                      ng-options="acf.name for acf in vm.acfs | orderBy:'name'"
+                      ng-options="(acf.identifer + ': ' + acf.name) for acf in vm.acfs | orderBy:'identifier'"
                       ng-keyup="$event.keyCode == 13 && vm.submitForm()">
               </select>
               <span class="text-danger form-control-static" ng-if="(vm.showFormErrors || vm.queryForm.selectAcf.$touched) && vm.queryForm.selectAcf.$error.required">An ACF must be selected</span>
@@ -32,7 +32,7 @@
             <div class="col-sm-6">
               <label for="selectAcfSuffix" class="control-label sr-only">ACF Suffix Selection</label>
               <select class="input-sm form-control" ng-model="vm.selectAcfSuffix" id="selectAcfSuffix" name="selectAcfSuffix" ng-disabled="!vm.acfs || vm.acfs.length === 0" ng-required="vm.mode === 'select'"
-                      ng-options="acfSuff for acfSuff in vm.acfSuffixes | orderBy:'toString()'">
+                      ng-options="(acfSuff + ' ' + vm.getName(vm.selectAcfPrefix + '-' + acfSuff)) for acfSuff in vm.acfSuffixes | orderBy:'toString()'">
               </select>
               <span class="text-danger form-control-static" ng-if="(vm.showFormErrors || vm.queryForm.selectAcfSuffix.$touched) && vm.queryForm.selectAcfSuffix.$error.required">An ACF suffix must be selected</span>
             </div>
@@ -59,12 +59,18 @@
           </div>
         </div>
         <div ng-if="vm.mode === 'enter' || vm.mode === 'edit'">
-          <div class="form-group" ng-class="{ 'has-error' : (vm.showFormErrors || vm.queryForm.acfName.$touched) && vm.queryForm.acfName.$error.required }">
-            <label for="acfName" class="col-sm-3 control-label">Name <span class="text-danger" ng-if="vm.acfWritesAllowed">*</span></label>
+          <div class="form-group" ng-class="{ 'has-error' : (vm.showFormErrors || vm.queryForm.acfIdentifier.$touched) && vm.queryForm.acfIdentifier.$error.required }">
+            <label for="acfIdentifier" class="col-sm-3 control-label">Identifier <span class="text-danger" ng-if="vm.acfWritesAllowed">*</span></label>
             <div class="col-sm-9">
-              <input class="input-sm form-control" type="text" ng-keyup="$event.keyCode == 13 && vm.submitForm()" ng-model="vm.acf.name" id="acfName" name="acfName" ng-required="(vm.mode === 'enter' || vm.mode === 'edit') && vm.acfWritesAllowed" ng-disabled="!vm.acfWritesAllowed"></input>
-              <span class="text-danger form-control-static" ng-if="(vm.showFormErrors || vm.queryForm.acfName.$touched) && vm.queryForm.acfName.$error.required">Field is required</span>
-              <span class="text-danger form-control-static" ng-if="(vm.showFormErrors || vm.queryForm.acfName.$touched) && (!vm.validName() && vm.mode === 'enter')">ACF already exists</span>
+              <input class="input-sm form-control" type="text" ng-keyup="$event.keyCode == 13 && vm.submitForm()" ng-model="vm.acf.identifier" id="acfIdentifier" name="acfIdentifier" ng-required="(vm.mode === 'enter' || vm.mode === 'edit') && vm.acfWritesAllowed" ng-disabled="!vm.acfWritesAllowed"></input>
+              <span class="text-danger form-control-static" ng-if="(vm.showFormErrors || vm.queryForm.acfIdentifier.$touched) && vm.queryForm.acfIdentifier.$error.required">Field is required</span>
+              <span class="text-danger form-control-static" ng-if="(vm.showFormErrors || vm.queryForm.acfIdentifier.$touched) && (!vm.validIdentifier() && vm.mode === 'enter')">ACF already exists</span>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="acfName" class="col-sm-3 control-label">Name</label>
+            <div class="col-sm-9">
+              <input class="input-sm form-control" type="text" ng-keyup="$event.keyCode == 13 && vm.submitForm()" ng-model="vm.acf.name" id="acfName" name="acfName"></input>
             </div>
           </div>
           <div class="form-group">
@@ -84,7 +90,7 @@
           </div>
           <div class="form-group" ng-if="vm.mode === 'enter'">
             <div class="col-sm-4 col-sm-offset-4">
-              <button ng-disabled="(vm.queryForm.$invalid || !vm.validName()) && vm.showFormErrors"
+              <button ng-disabled="(vm.queryForm.$invalid || !vm.validIdentifer()) && vm.showFormErrors"
                       class="btn btn-success btn-block"
                       id="acfSubmit"
                       ng-mouseover="vm.showFormErrors = true"
@@ -121,12 +127,12 @@
                       ng-click="vm.cancelEditing()">Cancel editing</button>
             </div>
           </div>
-          <div class="form-group" ng-if="(vm.queryForm.$invalid || (!vm.validName() && vm.mode === 'enter')) && vm.showFormErrors">
+          <div class="form-group" ng-if="(vm.queryForm.$invalid || (!vm.validIdentifier() && vm.mode === 'enter')) && vm.showFormErrors">
             <div class="col-sm-10 col-sm-offset-1 text-danger">
               The following error must be fixed:
               <ul>
-                <li ng-if="!vm.validName() && vm.mode === 'enter'">ACF already exists</li>
-                <li ng-if="vm.queryForm.acfName.$error.required">ACF Name is required</li>
+                <li ng-if="!vm.validIdentifier() && vm.mode === 'enter'">ACF already exists</li>
+                <li ng-if="vm.queryForm.acfIdentifier.$error.required">ACF Identifier is required</li>
               </ul>
             </div>
           </div>
@@ -144,7 +150,7 @@
       </span>
       <div ng-if="vm.acf.address && vm.acf.address"><ai-addresses fixed="true" addresses="[vm.acf.address]"></ai-addresses></div>
     </span>
-    <h3>{{ vm.acf.name }}</h3>
+    <h3>{{ vm.acf.identifier }}<small ng-if="vm.acf.name"> ({{ vm.acf.name }})</small></h3>
     <span ng-if="vm.acf.phoneNumber">{{ vm.acf.phoneNumber }}</span>
   </div>
 </div>

--- a/src/app/pulse.mock.js
+++ b/src/app/pulse.mock.js
@@ -8,6 +8,10 @@
     function  mock () {
         var mock = {};
 
+        mock.acfs = [{"id":179,"identifier":"Del Norte-04","name":"Elementary School","phoneNumber":"555-3258","address":{"id":null,"lines":["266 Seventh Way","475 View Gln"],"city":"Smith River","state":"CA","zipcode":"95543","country":null},"lastRead":1487616916883},
+                     {"id":1,"identifier":"Alameda-01","name":"Fairgrounds","phoneNumber":"555-1895","address":{"id":null,"lines":["395 Sunset Pky","133 Smith Gardn"],"city":"Albany","state":"CA","zipcode":"94602","country":null},"lastRead":1487616087349},
+                     {"id":452,"identifier":"Los Angeles-02","name":"Elementary School","phoneNumber":"555-3007","address":{"id":null,"lines":["887 Park Bridge","925 Center Strt"],"city":"Lancaster","state":"CA","zipcode":"91040","country":null},"lastRead":1487616087349},
+                     {"id":1450,"identifier":"Del Norte-02","name":"Fairgrounds","phoneNumber":"555-4451","address":{"id":null,"lines":["584 9th Ally","789 Fourteenth Radial"],"city":"Plumas Lake","state":"CA","zipcode":"95961","country":null},"lastRead":1487616087349}];
         mock.fakeModal = {
             result: {
                 then: function (confirmCallback, cancelCallback) {


### PR DESCRIPTION
Integrated identifier; revamped tests for ACF stuff. Not much change to HTML things; fingers crossed @brianlindsy's PR won't have any conflicts.

There's an error in the broker on ACF edit, but I think the UI is sending the right format